### PR TITLE
Frame send async js

### DIFF
--- a/examples/01_generic/src/interface.cpp
+++ b/examples/01_generic/src/interface.cpp
@@ -78,7 +78,7 @@ void block_demopage(Interface *interf, JsonObjectConst data, const char* action)
     // переключатель, связанный с переменной конфигурации V_LED - Изменяется синхронно
     interf->checkbox(V_LED, embui.getConfig()[V_LED],"Onboard LED", true);
 
-    interf->text(V_VAR1, embui.getConfig()[V_VAR1], "text field label");   // create text field with value from the system config
+    interf->text(V_VAR1, embui.getConfig()[V_VAR1].as<JsonVariant>(), "text field label");   // create text field with value from the system config
     interf->text(V_VAR2, "some default val", "another text label");         // текстовое поле со значением "по-умолчанию"
 
     /*  кнопка отправки данных секции на обработку

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -55,7 +55,7 @@ void EmbUI::http_set_handlers(){
 
 
     server.on("/version", HTTP_ANY, [this](AsyncWebServerRequest *request) {
-        request->send(200, PGmimetxt, F("EmbUI ver: " TOSTRING(EMBUIVER)));
+        request->send(200, PGmimetxt, "EmbUI ver: " TOSTRING(EMBUIVER));
     });
 
     // postponed reboot (TODO: convert to CMD)
@@ -77,7 +77,7 @@ void EmbUI::http_set_handlers(){
     // serve all static files from LittleFS root /
     server.serveStatic("/", LittleFS, "/")
         .setDefaultFile("index.html")
-        .setCacheControl("max-age=10, must-revalidate");  // 10 second for caching, then revalidate based on etag/IMS headers
+        .setCacheControl(asyncsrv::T_no_cache);  // revalidate based on etag/IMS headers
 
 
     // 404 handler - disabled to allow override in user code
@@ -103,7 +103,7 @@ uint8_t uploadProgress(size_t len, size_t total){
 
 void EmbUI::_http_api_hndlr(AsyncWebServerRequest *request, JsonVariant &json){
     // TODO:
-    // the specific for this handler is that it won't inject action responces to regostered feeders
+    // the specific for this handler is that it won't inject action responces to registered feeders
     // it's a design gap, I can't handle WS multimessaging and HTTP call in the same manner
     Interface interf(request);
     action.exec(&interf, json[P_data], json[P_action].as<const char*>());

--- a/src/ui.h
+++ b/src/ui.h
@@ -147,7 +147,7 @@ class FrameSendAsyncJS: public FrameSend {
     private:
         bool flushed = false;
         AsyncWebServerRequest *req;
-        AsyncJsonResponse response{ AsyncJsonResponse(false) };
+        AsyncJsonResponse *response;
     public:
         explicit FrameSendAsyncJS(AsyncWebServerRequest *request) : req(request) {}
         ~FrameSendAsyncJS();
@@ -210,7 +210,8 @@ class Interface {
 
         explicit Interface(AsyncWebSocket *server): _delete_handler_on_destruct(true), send_hndl(new FrameSendWSServer(server)) {}
         explicit Interface(AsyncWebSocketClient *client): _delete_handler_on_destruct(true), send_hndl(new FrameSendWSClient(client)) {}
-        explicit Interface(AsyncWebServerRequest *request): _delete_handler_on_destruct(true), send_hndl(new FrameSendHttp(request)) {}
+        explicit Interface(AsyncWebServerRequest *request): _delete_handler_on_destruct(true), send_hndl(new FrameSendAsyncJS(request)) {}
+
         // no copy c-tor
         Interface(const Interface&) = delete;
         Interface & operator=(const Interface&) = delete;


### PR DESCRIPTION
HTTP bases requests for `Interface()` should use FrameSendAsyncJS

HTTP requests for EmbUI API were behaving wrong when temporary FrameSendHttp object was injected/removed into chain. This could lead to a race condition and wrong reply to HTTP client sometimes.

Reworking it using FrameSendAsyncJS as HTTP handler and executing actions for this particular client only.